### PR TITLE
Improve handling of single job imports

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
@@ -147,14 +147,19 @@ public final class JobImportAction implements RootAction {
 
     try {
       if (StringUtils.isNotEmpty(remoteUrl)) {
-          Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(URLUtils.fetchUrl(remoteUrl + "/api/xml?tree=jobs[name,url,description]", username, password));
+          Document doc;
+          if(remoteUrl.matches("http://(?:.+)/jenkins/job/(?:.+)")){
+              doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(URLUtils.fetchUrl(remoteUrl + "/api/xml?xpath=*/url|*/name|*/description&wrapper=job", username, password));
+          } else {
+              doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(URLUtils.fetchUrl(remoteUrl + "/api/xml?tree=jobs[name,url,description]", username, password));
+          }
           NodeList nl = doc.getElementsByTagName("job");
           for (int i = 0; i < nl.getLength(); i++) {
               Element job = (Element) nl.item(i);
               String desc = text(job, "description");
               remoteJobs.add(new RemoteJob(text(job, "name"), text(job, "url"), desc != null ? desc : ""));
-          }
-      }
+          }          
+       }
     }
 
     catch (Exception e) {


### PR DESCRIPTION
Hi, noticed a problem with job-import-plugin when importing single jobs.

The url http://somejenkins.com/jenkins/job/jobname/api/xml?tree=jobs[name,url,description] doesn't lead anywhere for me in the current version of jenkins. Reason: can't get an xml tree for jobs from a single job.

Fix below first checks if url submitted is for a single job then gets the appropriate xml document
