### PR TITLE
Revert "remove redundant attributes"

### DIFF
--- a/src/main/resources/org/jenkins/ci/plugins/jobimport/JobImportAction/index.jelly
+++ b/src/main/resources/org/jenkins/ci/plugins/jobimport/JobImportAction/index.jelly
@@ -39,14 +39,14 @@
       <f:form name="query" action="query" method="get">
         <f:section title="${%Job.Import.Plugin.Query.Section.Title}">
           <f:entry title="${%Job.Import.Plugin.Query.Section.RemoteUrl.Title}" field="remoteUrl">
-            <f:textbox />
+            <f:textbox name="remoteUrl" field="remoteUrl" value="${it.remoteUrl}"/>
           </f:entry>
           <f:entry title="Username (optional)" field="username">
-            <f:textbox />
+            <f:textbox name="username" field="username" value="${it.username}"/>
           </f:entry>
           <!-- XXX offer a button to browse to /me/configure or /${username}/configure -->
           <f:entry title="Password/API Token" field="password">
-            <f:password />
+            <f:password name="password" field="password" value="${it.password}"/>
           </f:entry>
           <!--f:validateButton title="${%Job.Import.Plugin.Query.Section.Validate.Title}" method="doTestConnection" with="remoteUrl"/-->
           <f:block>


### PR DESCRIPTION
This reverts commit 0a4a5f004ae30d1f63a0b8677dc7c8ae9aa393d1.

This should fix the following bug which rendered 1.3 unusable

	https://issues.jenkins-ci.org/browse/JENKINS-33379