### PR TITLE
JENKINS-35983 - Add support to job import jobs in folders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Job+Import+Plugin</url>
 
   <properties>
-    <jenkins.version>1.580</jenkins.version>
+    <jenkins.version>1.609.1</jenkins.version>
     <java.level>6</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
@@ -102,6 +102,18 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>1.24</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <version>5.12</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>1.58</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkins/ci/plugins/jobimport/CredentialsUtils.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/CredentialsUtils.java
@@ -1,0 +1,59 @@
+package org.jenkins.ci.plugins.jobimport;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.google.common.base.Strings;
+import hudson.model.Item;
+import hudson.security.ACL;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.inject.internal.guava.base.$Preconditions.checkNotNull;
+
+/**
+ * Created by evildethow on 28/06/2016.
+ */
+final class CredentialsUtils {
+
+  private CredentialsUtils() {
+    throw new UnsupportedOperationException("Cannot instantiate utility class");
+  }
+
+  static NullSafeCredentials getCredentials(String credentialId) {
+    if (!Strings.isNullOrEmpty(credentialId)) {
+      StandardUsernamePasswordCredentials cred = CredentialsMatchers.firstOrNull(allCredentials(), CredentialsMatchers.withId(credentialId));
+      if (cred != null) {
+        return new NullSafeCredentials(cred.getUsername(), cred.getPassword().getPlainText());
+      }
+    }
+    return new NullSafeCredentials();
+  }
+
+  static List<StandardUsernamePasswordCredentials> allCredentials() {
+    return CredentialsProvider.lookupCredentials(
+        StandardUsernamePasswordCredentials.class,
+        (Item) null,
+        ACL.SYSTEM,
+        Collections.<DomainRequirement>emptyList()
+    );
+  }
+
+  static final class NullSafeCredentials {
+
+    final String username;
+    final String password;
+
+    NullSafeCredentials(String username, String password) {
+      this.username = checkNotNull(username);
+      this.password = checkNotNull(password);
+    }
+
+    NullSafeCredentials() {
+      this.username = "";
+      this.password = "";
+    }
+  }
+}

--- a/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
@@ -24,44 +24,39 @@
 
 package org.jenkins.ci.plugins.jobimport;
 
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
-import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import com.google.common.base.Strings;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Item;
 import hudson.model.RootAction;
 import hudson.model.TopLevelItem;
-import hudson.security.ACL;
 import hudson.util.FormValidation;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.servlet.ServletException;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jenkins.ci.plugins.jobimport.CredentialsUtils.NullSafeCredentials;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import javax.servlet.ServletException;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.jenkins.ci.plugins.jobimport.CredentialsUtils.allCredentials;
+import static org.jenkins.ci.plugins.jobimport.RemoteJobUtils.getRemoteJob;
 
 /**
  * @author <a href="mailto:jieryn@gmail.com">Jesse Farinacci</a>
@@ -71,6 +66,11 @@ import org.w3c.dom.NodeList;
 public final class JobImportAction implements RootAction, Describable<JobImportAction> {
 
   private static final Logger LOG = Logger.getLogger(JobImportAction.class.getName());
+
+  static final String URL_NAME= "job-import";
+  static final String REMOTE_URL_PARAM = "remoteUrl";
+  static final String JOB_URL_PARAM = "jobUrl";
+  static final String XML_API_QUERY = "/api/xml?tree=jobs[name,url,description]";
 
   private String remoteUrl;
   private String credentialId;
@@ -84,7 +84,7 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
     credentialId = null;
     remoteJobs.clear();
     remoteJobsImportStatus.clear();
-    response.sendRedirect(Jenkins.getInstance().getRootUrl());
+    response.sendRedirect(Jenkins.getActiveInstance().getRootUrl());
   }
 
   public void doImport(final StaplerRequest request, final StaplerResponse response) throws ServletException,
@@ -92,123 +92,125 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
     remoteJobsImportStatus.clear();
 
     if (isRemoteJobsAvailable()) {
-      if (request.hasParameter("jobUrl")) {
-        for (final String jobUrl : Arrays.asList(request.getParameterValues("jobUrl"))) {
-          final RemoteJob remoteJob = getRemoteJobs(jobUrl);
-          if (remoteJob != null) {
-            if (!remoteJobsImportStatus.containsKey(remoteJob)) {
-              remoteJobsImportStatus.put(remoteJob, new RemoteJobImportStatus(remoteJob));
-            }
-
-            // ---
-
-            if (Jenkins.getInstance().getItem(remoteJob.getName()) != null) {
-              remoteJobsImportStatus.get(remoteJob).setStatus(MessagesUtils.formatFailedDuplicateJobName());
-            }
-
-            else {
-              InputStream inputStream = null;
-
-              String username = "";
-              String password = "";
-
-              if (!Strings.isNullOrEmpty(credentialId)) {
-                StandardUsernamePasswordCredentials cred = CredentialsMatchers.firstOrNull(
-                        allCredentials(),
-                        CredentialsMatchers.withId(credentialId)
-                );
-                if (cred != null) {
-                  username = cred.getUsername();
-                  password = cred.getPassword().getPlainText();
-                }
-              }
-
-              try {
-                  inputStream = URLUtils.fetchUrl(remoteJob.getUrl() + "/config.xml", username, password);
-                  Jenkins.getInstance().createProjectFromXML(remoteJob.getName(), inputStream);
-                  remoteJobsImportStatus.get(remoteJob).setStatus(MessagesUtils.formatSuccess());
-              }
-
-              catch (final Exception e) {
-                LOG.warning("Job Import Failed: " + e.getMessage());
-                if (LOG.isLoggable(Level.INFO)) {
-                  LOG.log(Level.INFO, e.getMessage(), e);
-                }
-
-                // ---
-
-                remoteJobsImportStatus.get(remoteJob).setStatus(MessagesUtils.formatFailedException(e));
-
-                try {
-                    TopLevelItem created = Jenkins.getInstance().getItem(remoteJob.getName());
-                    if (created != null) {
-                        created.delete();
-                    }
-                }
-                catch (final InterruptedException e2) {
-                  // do nothing
-                }
-              }
-
-              finally {
-                IOUtils.closeQuietly(inputStream);
-              }
-            }
-          }
+      if (request.hasParameter(JOB_URL_PARAM)) {
+        for (final String jobUrl : Arrays.asList(request.getParameterValues(JOB_URL_PARAM))) {
+          doImportInternal(jobUrl);
         }
       }
     }
 
     response.forwardToPreviousPage(request);
+  }
+
+  private void doImportInternal(String jobUrl) throws IOException {
+    final RemoteJob remoteJob = getRemoteJob(remoteJobs, jobUrl);
+    if (remoteJob != null) {
+      if (!remoteJobsImportStatus.containsKey(remoteJob)) {
+        remoteJobsImportStatus.put(remoteJob, new RemoteJobImportStatus(remoteJob));
+      }
+
+      // ---
+
+      if (Jenkins.getActiveInstance().getItem(remoteJob.getName()) != null) {
+        remoteJobsImportStatus.get(remoteJob).setStatus(MessagesUtils.formatFailedDuplicateJobName());
+      }
+
+      else {
+        InputStream inputStream = null;
+
+        NullSafeCredentials credentials = CredentialsUtils.getCredentials(credentialId);
+
+        try {
+          inputStream = URLUtils.fetchUrl(remoteJob.getUrl() + "/config.xml", credentials.username, credentials.password);
+          Jenkins.getActiveInstance().createProjectFromXML(remoteJob.getFullName(), inputStream);
+          remoteJobsImportStatus.get(remoteJob).setStatus(MessagesUtils.formatSuccess());
+
+          if (remoteJob.hasChildren()) {
+            for (RemoteJob childJob : remoteJob.getChildren()) {
+              doImportInternal(childJob.getUrl());
+            }
+          }
+          Jenkins.getActiveInstance().doReload();
+        }
+
+        catch (final Exception e) {
+          LOG.warning("Job Import Failed: " + e.getMessage());
+          if (LOG.isLoggable(Level.INFO)) {
+            LOG.log(Level.INFO, e.getMessage(), e);
+          }
+
+          // ---
+
+          remoteJobsImportStatus.get(remoteJob).setStatus(MessagesUtils.formatFailedException(e));
+
+          try {
+            TopLevelItem created = Jenkins.getActiveInstance().getItem(remoteJob.getName());
+            if (created != null) {
+              created.delete();
+            }
+          }
+          catch (final InterruptedException e2) {
+            // do nothing
+          }
+        }
+
+        finally {
+          IOUtils.closeQuietly(inputStream);
+        }
+      }
+    }
   }
 
   public void doQuery(final StaplerRequest request, final StaplerResponse response) throws ServletException,
       IOException {
     remoteJobs.clear();
     remoteJobsImportStatus.clear();
-    remoteUrl = request.getParameter("remoteUrl");
-    String username = "";
-    String password = "";
+    remoteUrl = request.getParameter(REMOTE_URL_PARAM);
     credentialId = request.getParameter("_.credentialId");
 
-    if (!Strings.isNullOrEmpty(credentialId)) {
-        StandardUsernamePasswordCredentials cred = CredentialsMatchers.firstOrNull(
-            allCredentials(),
-            CredentialsMatchers.withId(credentialId)
-        );
-        if (cred != null) {
-            username = cred.getUsername();
-            password = cred.getPassword().getPlainText();
-        }
-    }
+    doQueryInternal(null, remoteUrl, CredentialsUtils.getCredentials(credentialId));
 
+    response.forwardToPreviousPage(request);
+  }
 
+  private void doQueryInternal(RemoteJob parent, String url, NullSafeCredentials credentials) {
     try {
-      if (StringUtils.isNotEmpty(remoteUrl)) {
-          Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(URLUtils.fetchUrl(remoteUrl + "/api/xml?tree=jobs[name,url,description]", username, password));
-          NodeList nl = doc.getElementsByTagName("job");
-          for (int i = 0; i < nl.getLength(); i++) {
-              Element job = (Element) nl.item(i);
-              String desc = text(job, "description");
-              remoteJobs.add(new RemoteJob(text(job, "name"), text(job, "url"), desc != null ? desc : ""));
+      if (StringUtils.isNotEmpty(url)) {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(URLUtils.fetchUrl(url + XML_API_QUERY, credentials.username, credentials.password));
+        NodeList nl = doc.getElementsByTagName("job");
+        for (int i = 0; i < nl.getLength(); i++) {
+          Element job = (Element) nl.item(i);
+          String desc = text(job, "description");
+          String jobUrl = text(job, "url");
+          String name = text(job, "name");
+
+          RemoteJob remoteJob;
+          if (parent == null) {
+            remoteJob = new RemoteJob(name, jobUrl, desc, null);
+            remoteJobs.add(remoteJob);
+          } else {
+            remoteJob = new RemoteJob(name, jobUrl, desc, parent);
+            parent.getChildren().add(remoteJob);
           }
+
+          doQueryInternal(remoteJob, jobUrl, credentials);
+        }
       }
     }
 
     catch (Exception e) {
-        LOG.log(Level.SEVERE, (new StringBuilder()).append("Failed to import job from remote ").append(remoteUrl).toString(), e);
+      LOG.log(Level.SEVERE, (new StringBuilder()).append("Failed to import job from remote ").append(url).toString(), e);
     }
-
-    response.forwardToPreviousPage(request);
   }
+
   private static String text(Element e, String name) {
-      NodeList nl = e.getElementsByTagName(name);
-      if (nl.getLength() == 1) {
-          Element e2 = (Element) nl.item(0);
-          return e2.getTextContent();
-      } else {
-          return null;
-      }
+    NodeList nl = e.getElementsByTagName(name);
+    if (nl.getLength() == 1) {
+      Element e2 = (Element) nl.item(0);
+      return e2.getTextContent();
+    } else {
+      return null;
+    }
   }
 
   public FormValidation doTestConnection(@QueryParameter("remoteUrl") final String remoteUrl) {
@@ -216,7 +218,7 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
   }
 
   public String getRootUrl() {
-      return Jenkins.getInstance().getRootUrl();
+      return Jenkins.getActiveInstance().getRootUrl();
   }
 
   public String getDisplayName() {
@@ -231,18 +233,6 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
     return remoteJobs;
   }
 
-  private RemoteJob getRemoteJobs(final String jobUrl) {
-    if (StringUtils.isNotEmpty(jobUrl)) {
-      for (final RemoteJob remoteJob : remoteJobs) {
-        if (jobUrl.equals(remoteJob.getUrl())) {
-          return remoteJob;
-        }
-      }
-    }
-
-    return null;
-  }
-
   public SortedMap<RemoteJob, RemoteJobImportStatus> getRemoteJobsImportStatus() {
     return remoteJobsImportStatus;
   }
@@ -252,7 +242,7 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
   }
 
   public String getUrlName() {
-    return "/job-import";
+    return "/" + URL_NAME;
   }
 
   public boolean isRemoteJobsAvailable() {
@@ -269,23 +259,11 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
 
   public String getCredentialId() { return credentialId; }
   
-  private static List<StandardUsernamePasswordCredentials> allCredentials() {
-    return CredentialsProvider.lookupCredentials(
-      StandardUsernamePasswordCredentials.class,
-      (Item) null,
-      ACL.SYSTEM,
-      Collections.<DomainRequirement>emptyList()
-    );
-  }
+
 
   @Override
   public Descriptor<JobImportAction> getDescriptor() {
-    // TODO switch to Jenkins.getActiveInstance() once 1.590+ is the baseline
-    Jenkins jenkins = Jenkins.getInstance();
-    if (jenkins == null) {
-      throw new IllegalStateException("Jenkins has not been started, or was already shut down");
-    }
-    return jenkins.getDescriptorOrDie(getClass());
+    return Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
   }
   
   @Extension

--- a/src/main/java/org/jenkins/ci/plugins/jobimport/RemoteJob.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/RemoteJob.java
@@ -24,61 +24,63 @@
 
 package org.jenkins.ci.plugins.jobimport;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.jenkins.ci.plugins.jobimport.RemoteJobUtils.cleanRemoteString;
+import static org.jenkins.ci.plugins.jobimport.RemoteJobUtils.fullName;
 
 /**
  * @author <a href="mailto:jieryn@gmail.com">Jesse Farinacci</a>
  * @since 1.0
  */
 public final class RemoteJob implements Comparable<RemoteJob> {
-  private String name;
-  private String url;
-  private String description;
+  private final String name;
+  private final String url;
+  private final String description;
+  private final RemoteJob parent;
+  private final SortedSet<RemoteJob> children = new TreeSet<RemoteJob>();
 
-  public RemoteJob() {
-    this((String) null, (String) null, (String) null);
-  }
-
-  public RemoteJob(final String name) {
-    this(name, (String) null, (String) null);
-  }
-
-  public RemoteJob(final String name, final String url) {
-    this(name, url, (String) null);
-  }
-
-  public RemoteJob(final String name, final String url, final String description) {
-    super();
+  public RemoteJob(final String name, final String url, final String description, RemoteJob parent) {
     this.name = name;
     this.url = url;
-    this.description = cleanRemoteString(description);
+    this.description = cleanRemoteString(description != null ? description : "");
+    this.parent = parent;
   }
 
   public String getName() {
     return name;
   }
 
-  public void setName(final String name) {
-    this.name = name;
-  }
-
   public String getUrl() {
     return url;
-  }
-
-  public void setUrl(final String url) {
-    this.url = url;
   }
 
   public String getDescription() {
     return description;
   }
 
-  public void setDescription(final String description) {
-    this.description = cleanRemoteString(description);
+  public RemoteJob getParent() {
+    return parent;
   }
 
+  public SortedSet<RemoteJob> getChildren() {
+    return children;
+  }
+
+  boolean hasChildren() {
+    return !this.children.isEmpty();
+  }
+
+  boolean hasParent() {
+    return this.parent != null;
+  }
+
+  public String getFullName() {
+    return fullName(this);
+  }
+
+  @Override
   public int compareTo(final RemoteJob other) {
     if (this == other) {
       return 0;
@@ -89,15 +91,8 @@ public final class RemoteJob implements Comparable<RemoteJob> {
 
   @Override
   public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
+    return this == obj || obj instanceof RemoteJob && name.equals(((RemoteJob) obj).getName());
 
-    if (!(obj instanceof RemoteJob)) {
-      return false;
-    }
-
-    return name.equals(((RemoteJob) obj).getName());
   }
 
   @Override
@@ -107,13 +102,6 @@ public final class RemoteJob implements Comparable<RemoteJob> {
 
   @Override
   public String toString() {
-    return new StringBuilder().append("RemoteJob: ").append(name).append(", ").append(url).append(", ")
-        .append(description).toString();
-  }
-
-  protected static final int MAX_STRLEN = 4096;
-
-  protected static final String cleanRemoteString(final String string) {
-    return StringUtils.substring(StringEscapeUtils.escapeHtml(string), 0, MAX_STRLEN);
+    return "RemoteJob: " + name + ", " + url + ", " + description;
   }
 }

--- a/src/main/java/org/jenkins/ci/plugins/jobimport/RemoteJobUtils.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/RemoteJobUtils.java
@@ -1,0 +1,61 @@
+package org.jenkins.ci.plugins.jobimport;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+
+/**
+ * Created by evildethow on 28/06/2016.
+ */
+final class RemoteJobUtils {
+
+  private RemoteJobUtils() {
+    throw new UnsupportedOperationException("Cannot instantiate utility class");
+  }
+
+  static String fullName(RemoteJob remoteJob) {
+    if (remoteJob == null) {
+      return "";
+    }
+
+    if (!remoteJob.hasParent()) {
+      return remoteJob.getName();
+    }
+
+    return StringUtils.substringBeforeLast(fullName(remoteJob, ""), "jobs/");
+  }
+
+  private static String fullName(RemoteJob remoteJob, String name) {
+    name = remoteJob.getName() + "/jobs/" + name;
+    return remoteJob.hasParent() ? fullName(remoteJob.getParent(), name) : name;
+  }
+
+  private static final int MAX_STR_LEN = 4096;
+
+  static String cleanRemoteString(final String string) {
+    return StringUtils.substring(StringEscapeUtils.escapeHtml(string), 0, MAX_STR_LEN);
+  }
+
+  static RemoteJob getRemoteJob(SortedSet<RemoteJob> remoteJobs, String jobUrl) {
+    List<RemoteJob> matches  = new ArrayList<RemoteJob>();
+
+    findRemoteJob(remoteJobs, jobUrl, matches);
+
+    return matches.isEmpty() ? null : matches.get(0);
+  }
+
+  private static void findRemoteJob(SortedSet<RemoteJob> remoteJobs, String jobUrl, List<RemoteJob> matches) {
+    if (StringUtils.isNotEmpty(jobUrl) && matches.isEmpty()) {
+      for (final RemoteJob remoteJob : remoteJobs) {
+        if (jobUrl.trim().equals(remoteJob.getUrl().trim())) {
+          matches.add(remoteJob);
+        } else if (remoteJob.hasChildren()) {
+          findRemoteJob(remoteJob.getChildren(), jobUrl, matches);
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/org/jenkins/ci/plugins/jobimport/JobImportActionTest.java
+++ b/src/test/java/org/jenkins/ci/plugins/jobimport/JobImportActionTest.java
@@ -1,0 +1,42 @@
+package org.jenkins.ci.plugins.jobimport;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+/**
+ * Created by evildethow on 29/06/2016.
+ */
+public class JobImportActionTest {
+
+  @Rule
+  public JenkinsRule jenkinsRule = new JenkinsRule();
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+  private JobImportClient client;
+  private RemoteJenkins remoteJenkins;
+
+  @Before
+  public void setUp() throws Exception {
+    client = new JobImportClient(jenkinsRule.createWebClient());
+    remoteJenkins = new RemoteJenkins(wireMockRule.port());
+  }
+
+  @Test
+  public void doImport() throws Exception {
+    client.doQuerySubmit(remoteJenkins.getUrl());
+
+    remoteJenkins.verifyQueried();
+
+    client.selectJobs();
+    client.doImportSubmit();
+
+    remoteJenkins.verifyImported();
+  }
+}

--- a/src/test/java/org/jenkins/ci/plugins/jobimport/JobImportClient.java
+++ b/src/test/java/org/jenkins/ci/plugins/jobimport/JobImportClient.java
@@ -1,0 +1,56 @@
+package org.jenkins.ci.plugins.jobimport;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.html.*;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.jenkins.ci.plugins.jobimport.JobImportAction.JOB_URL_PARAM;
+import static org.jenkins.ci.plugins.jobimport.JobImportAction.REMOTE_URL_PARAM;
+import static org.jenkins.ci.plugins.jobimport.JobImportAction.URL_NAME;
+
+/**
+ * Created by evildethow on 30/06/2016.
+ */
+public final class JobImportClient {
+
+  private static final int IMPORT_SUBMIT_RETRY = 5;
+  private static final long IMPORT_SUBMIT_RETRY_WAIT_TIME = 1000L;
+
+  private HtmlPage currentPage;
+
+  public JobImportClient(JenkinsRule.WebClient webClient) throws Exception {
+    this.currentPage = webClient.goTo(URL_NAME);
+  }
+
+  public void doQuerySubmit(String remoteUrl) throws Exception {
+    HtmlInput input = (HtmlInput) currentPage.getElementsByName(REMOTE_URL_PARAM).get(0);
+    input.setValueAttribute(remoteUrl);
+    HtmlForm form = currentPage.getFormByName("query");
+    currentPage = form.getInputByValue("Query!").click();
+  }
+
+  public void selectJobs() {
+    for (DomElement checkBox : currentPage.getElementsByName(JOB_URL_PARAM)) {
+      ((HtmlCheckBoxInput) checkBox).setChecked(true);
+    }
+  }
+
+  public void doImportSubmit() throws Exception {
+    doImportSubmitWithRetry(IMPORT_SUBMIT_RETRY);
+  }
+
+  private void doImportSubmitWithRetry(int retry) throws Exception {
+    try {
+      HtmlForm form = currentPage.getFormByName("import");
+      currentPage = form.getInputByValue("Import!").click();
+    } catch (FailingHttpStatusCodeException e) {
+      if (retry > 0) {
+        Thread.sleep(IMPORT_SUBMIT_RETRY_WAIT_TIME);
+        retry--;
+        doImportSubmitWithRetry(retry);
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/src/test/java/org/jenkins/ci/plugins/jobimport/RemoteJenkins.java
+++ b/src/test/java/org/jenkins/ci/plugins/jobimport/RemoteJenkins.java
@@ -1,0 +1,166 @@
+package org.jenkins.ci.plugins.jobimport;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static java.io.File.separator;
+import static org.jenkins.ci.plugins.jobimport.JobImportAction.XML_API_QUERY;
+
+/**
+ * Created by evildethow on 30/06/2016.
+ */
+public final class RemoteJenkins {
+
+  private static final String BASE_URL = "http://localhost";
+
+  private static final String TOP_LVL_RSP_XML = "xml-api-response.xml";
+  private static final String SECOND_LVL_RSP_XML = "folder" + separator + "xml-api-response.xml";
+  private static final String THIRD_LVL_RSP_XML = "folder" + separator + "jobs" + separator + "aFolder" + separator + "xml-api-response.xml";
+
+  private static final String TOP_LVL_QUERY = XML_API_QUERY;
+  private static final String SECOND_LVL_FOLDER_QUERY = "/job/folder/" + XML_API_QUERY;
+  private static final String SECOND_LVL_JOB_QUERY = "/job/job/" + XML_API_QUERY;
+  private static final String THIRD_LVL_A_FOLDER_QUERY = "/job/folder/job/aFolder/" + XML_API_QUERY;
+  private static final String THIRD_LVL_A_FREESTYLE_JOB_IN_FOLDER_QUERY = "/job/folder/job/aFreestyleJobInFolder/" + XML_API_QUERY;
+  private static final String THIRD_LVL_A_MAVEN_JOB_IN_FOLDER_QUERY = "/job/folder/job/aMavenJobInFolder/" + XML_API_QUERY;
+  private static final String FOURTH_LVL_B_FREESTYLE_JOB_IN_A_FOLDER_QUERY = "/job/folder/job/aFolder/job/bFreestyleJobInFolder/" + XML_API_QUERY;
+  private static final String FOURTH_LVL_B_MAVEN_JOB_IN_A_FOLDER_QUERY = "/job/folder/job/aFolder/job/bMavenJobInFolder/" + XML_API_QUERY;
+
+  private static final String EMPTY_FREESTYLE_JOB_BODY = "<freeStyleProject/>";
+  private static final String EMPTY_MAVEN_JOB_BODY = "<mavenModuleSet/>";
+
+  private static final String FOLDER_CONFIG_QUERY = "/job/folder//config.xml";
+  private static final String JOB_CONFIG_QUERY = "/job/job//config.xml";
+  private static final String A_FOLDER_CONFIG_QUERY = "/job/folder/job/aFolder//config.xml";
+  private static final String A_FREESTYLE_JOB_IN_FOLDER_CONFIG_QUERY = "/job/folder/job/aFreestyleJobInFolder//config.xml";
+  private static final String A_MAVEN_JOB_IN_FOLDER_CONFIG_QUERY = "/job/folder/job/aMavenJobInFolder//config.xml";
+  private static final String B_FREESTYLE_JOB_IN_FOLDER_CONFIG_QUERY = "/job/folder/job/aFolder/job/bFreestyleJobInFolder//config.xml";
+  private static final String B_MAVEN_JOB_IN_FOLDER_CONFIG_QUERY = "/job/folder/job/aFolder/job/bMavenJobInFolder//config.xml";
+
+  private static final String FOLDER_CONFIG = "folder" + separator + "config.xml";
+  private static final String JOB_CONFIG = "job" + separator + "config.xml";
+  private static final String A_FOLDER_CONFIG = "folder" + separator + "jobs" + separator + "aFolder" + separator + "config.xml";
+  private static final String A_FREESTYLE_JOB_IN_FOLDER_CONFIG = "folder" + separator + "jobs" + separator + "aFreestyleJobInFolder" + separator + "config.xml";
+  private static final String A_MAVEN_JOB_IN_FOLDER_CONFIG = "folder" + separator + "jobs" + separator + "aMavenJobInFolder" + separator + "config.xml";
+  private static final String B_FREESTYLE_JOB_IN_FOLDER_CONFIG = "folder" + separator + "jobs" + separator + "aFolder" + separator + "jobs" + separator + "bFreestyleJobInFolder" + separator + "config.xml";
+  private static final String B_MAVEN_JOB_IN_FOLDER_CONFIG = "folder" + separator + "jobs" + separator + "aFolder" + separator + "jobs" + separator + "bMavenJobInFolder" + separator + "config.xml";
+
+  private final String url;
+
+  public RemoteJenkins(int port) {
+    this.url = BASE_URL + ":" + port;
+
+    stubQueryResponses();
+    stubImportResponses();
+  }
+
+  private void stubQueryResponses() {
+    stubTopLevelResponse();
+    stubSecondLevelResponse();
+    stubThirdLevelResponse();
+    stubFourthLevelResponse();
+  }
+
+  private void stubImportResponses() {
+    stubTopLevelConfigResponse();
+    stubSecondLevelConfigResponse();
+    stubThirdLevelConfigResponse();
+  }
+
+  private void stubTopLevelResponse() {
+    stubGetRequest(TOP_LVL_QUERY, getResponse(TOP_LVL_RSP_XML));
+  }
+
+  private void stubSecondLevelResponse() {
+    stubGetRequest(SECOND_LVL_FOLDER_QUERY, getResponse(SECOND_LVL_RSP_XML));
+    stubGetRequest(SECOND_LVL_JOB_QUERY, EMPTY_FREESTYLE_JOB_BODY);
+  }
+
+  private void stubThirdLevelResponse() {
+    stubGetRequest(THIRD_LVL_A_FOLDER_QUERY, getResponse(THIRD_LVL_RSP_XML));
+    stubGetRequest(THIRD_LVL_A_FREESTYLE_JOB_IN_FOLDER_QUERY, EMPTY_FREESTYLE_JOB_BODY);
+    stubGetRequest(THIRD_LVL_A_MAVEN_JOB_IN_FOLDER_QUERY, EMPTY_MAVEN_JOB_BODY);
+  }
+
+  private void stubFourthLevelResponse() {
+    stubGetRequest(FOURTH_LVL_B_FREESTYLE_JOB_IN_A_FOLDER_QUERY, EMPTY_FREESTYLE_JOB_BODY);
+    stubGetRequest(FOURTH_LVL_B_MAVEN_JOB_IN_A_FOLDER_QUERY, EMPTY_MAVEN_JOB_BODY);
+  }
+
+  private void stubTopLevelConfigResponse() {
+    stubGetRequest(FOLDER_CONFIG_QUERY, getResponse(FOLDER_CONFIG));
+    stubGetRequest(JOB_CONFIG_QUERY, getResponse(JOB_CONFIG));
+  }
+
+  private void stubSecondLevelConfigResponse() {
+    stubGetRequest(A_FOLDER_CONFIG_QUERY, getResponse(A_FOLDER_CONFIG));
+    stubGetRequest(A_FREESTYLE_JOB_IN_FOLDER_CONFIG_QUERY, getResponse(A_FREESTYLE_JOB_IN_FOLDER_CONFIG));
+    stubGetRequest(A_MAVEN_JOB_IN_FOLDER_CONFIG_QUERY, getResponse(A_MAVEN_JOB_IN_FOLDER_CONFIG));
+  }
+
+  private void stubThirdLevelConfigResponse() {
+    stubGetRequest(B_FREESTYLE_JOB_IN_FOLDER_CONFIG_QUERY, getResponse(B_FREESTYLE_JOB_IN_FOLDER_CONFIG));
+    stubGetRequest(B_MAVEN_JOB_IN_FOLDER_CONFIG_QUERY, getResponse(B_MAVEN_JOB_IN_FOLDER_CONFIG));
+  }
+
+  private void stubGetRequest(String url, String template) {
+    stubFor(get(urlEqualTo(url))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withBody(template)));
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void verifyQueried() {
+    verifyGetRequest(TOP_LVL_QUERY);
+    verifyGetRequest(SECOND_LVL_FOLDER_QUERY);
+    verifyGetRequest(SECOND_LVL_JOB_QUERY);
+    verifyGetRequest(THIRD_LVL_A_FOLDER_QUERY);
+    verifyGetRequest(THIRD_LVL_A_FREESTYLE_JOB_IN_FOLDER_QUERY);
+    verifyGetRequest(THIRD_LVL_A_MAVEN_JOB_IN_FOLDER_QUERY);
+    verifyGetRequest(FOURTH_LVL_B_FREESTYLE_JOB_IN_A_FOLDER_QUERY);
+    verifyGetRequest(FOURTH_LVL_B_MAVEN_JOB_IN_A_FOLDER_QUERY);
+  }
+
+  public void verifyImported() {
+    verifyGetRequest(FOLDER_CONFIG_QUERY);
+    verifyGetRequest(JOB_CONFIG_QUERY);
+    verifyGetRequest(A_FOLDER_CONFIG_QUERY);
+    verifyGetRequest(A_FREESTYLE_JOB_IN_FOLDER_CONFIG_QUERY);
+    verifyGetRequest(A_MAVEN_JOB_IN_FOLDER_CONFIG_QUERY);
+    verifyGetRequest(B_FREESTYLE_JOB_IN_FOLDER_CONFIG_QUERY);
+    verifyGetRequest(B_MAVEN_JOB_IN_FOLDER_CONFIG_QUERY);
+  }
+  
+  private void verifyGetRequest(String url) {
+    verify(getRequestedFor(urlEqualTo(url)));
+  }
+
+  private static final String FIELD_START = "\\$\\{";
+  private static final String FIELD_END = "\\}";
+  private static final String REGEX = FIELD_START + "(baseUrl)" + FIELD_END;
+
+  private String getResponse(String template) {
+    String rawXml = templateToString(template);
+    return rawXml.replaceAll(REGEX, url);
+  }
+
+  private String templateToString(String template) {
+    try {
+      return IOUtils.toString(Thread.currentThread().getContextClassLoader().getResourceAsStream(template));
+    } catch (IOException e) {
+      throw new RemoteJenkinsIOException(e.getMessage());
+    }
+  }
+
+  private static final class RemoteJenkinsIOException extends RuntimeException {
+    RemoteJenkinsIOException(String message) {
+      super(message);
+    }
+  }
+}

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,0 +1,19 @@
+```
+.
+├── folder
+│   ├── config.xml
+│   └── jobs
+│       ├── aFolder
+│       │   ├── config.xml
+│       │   └── jobs
+│       │       ├── bFreestyleJobInFolder
+│       │       │   ├── config.xml
+│       │       └── bMavenJobInFolder
+│       │           ├── config.xml
+│       ├── aFreestyleJobInFolder
+│       │   ├── config.xml
+│       └── aMavenJobInFolder
+│           ├── config.xml
+├── job
+│   ├── config.xml
+```

--- a/src/test/resources/folder/config.xml
+++ b/src/test/resources/folder/config.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@5.12">
+  <actions/>
+  <description></description>
+  <properties>
+    <com.cloudbees.jenkins.plugins.foldersplus.SecurityGrantsFolderProperty plugin="cloudbees-folders-plus@3.0">
+      <securityGrants/>
+    </com.cloudbees.jenkins.plugins.foldersplus.SecurityGrantsFolderProperty>
+    <com.cloudbees.hudson.plugins.folder.properties.EnvVarsFolderProperty plugin="cloudbees-folders-plus@3.0">
+      <properties></properties>
+    </com.cloudbees.hudson.plugins.folder.properties.EnvVarsFolderProperty>
+    <com.cloudbees.hudson.plugins.folder.properties.SubItemFilterProperty plugin="cloudbees-folders-plus@3.0"/>
+  </properties>
+  <views>
+    <hudson.model.AllView>
+      <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric/>
+    <com.cloudbees.hudson.plugins.folder.health.AverageChildHealthMetric plugin="cloudbees-folders-plus@3.0"/>
+    <com.cloudbees.hudson.plugins.folder.health.JobStatusHealthMetric plugin="cloudbees-folders-plus@3.0">
+      <success>true</success>
+      <failure>true</failure>
+      <unstable>true</unstable>
+      <unbuilt>true</unbuilt>
+      <countVirginJobs>false</countVirginJobs>
+    </com.cloudbees.hudson.plugins.folder.health.JobStatusHealthMetric>
+    <com.cloudbees.hudson.plugins.folder.health.ProjectEnabledHealthMetric plugin="cloudbees-folders-plus@3.0"/>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/src/test/resources/folder/jobs/aFolder/config.xml
+++ b/src/test/resources/folder/jobs/aFolder/config.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@5.12">
+  <actions/>
+  <description></description>
+  <properties>
+    <com.cloudbees.jenkins.plugins.foldersplus.SecurityGrantsFolderProperty plugin="cloudbees-folders-plus@3.0">
+      <securityGrants/>
+    </com.cloudbees.jenkins.plugins.foldersplus.SecurityGrantsFolderProperty>
+    <com.cloudbees.hudson.plugins.folder.properties.EnvVarsFolderProperty plugin="cloudbees-folders-plus@3.0">
+      <properties></properties>
+    </com.cloudbees.hudson.plugins.folder.properties.EnvVarsFolderProperty>
+    <com.cloudbees.hudson.plugins.folder.properties.SubItemFilterProperty plugin="cloudbees-folders-plus@3.0"/>
+  </properties>
+  <views>
+    <hudson.model.AllView>
+      <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric/>
+    <com.cloudbees.hudson.plugins.folder.health.AverageChildHealthMetric plugin="cloudbees-folders-plus@3.0"/>
+    <com.cloudbees.hudson.plugins.folder.health.JobStatusHealthMetric plugin="cloudbees-folders-plus@3.0">
+      <success>true</success>
+      <failure>true</failure>
+      <unstable>true</unstable>
+      <unbuilt>true</unbuilt>
+      <countVirginJobs>false</countVirginJobs>
+    </com.cloudbees.hudson.plugins.folder.health.JobStatusHealthMetric>
+    <com.cloudbees.hudson.plugins.folder.health.ProjectEnabledHealthMetric plugin="cloudbees-folders-plus@3.0"/>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/src/test/resources/folder/jobs/aFolder/jobs/bFreestyleJobInFolder/config.xml
+++ b/src/test/resources/folder/jobs/aFolder/jobs/bFreestyleJobInFolder/config.xml
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.cloudbees.plugins.deployer.DeployNowJobProperty plugin="deployer-framework@1.1">
+      <oneClickDeploy>false</oneClickDeploy>
+      <hosts>
+        <com.cloudbees.plugins.deployer.impl.amazon.HostImpl plugin="cloudbees-aws-deployer@1.15">
+          <targets class="java.util.Collections$UnmodifiableRandomAccessList" resolves-to="java.util.Collections$UnmodifiableList">
+            <c class="list"/>
+            <list reference="../c"/>
+          </targets>
+          <credentialsId></credentialsId>
+        </com.cloudbees.plugins.deployer.impl.amazon.HostImpl>
+      </hosts>
+    </com.cloudbees.plugins.deployer.DeployNowJobProperty>
+    <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28"/>
+    <com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty plugin="build-failure-analyzer@1.16.0">
+      <doNotScan>false</doNotScan>
+    </com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17.1">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+      <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
+      <paramsToUseForLimit></paramsToUseForLimit>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/folder/jobs/aFolder/jobs/bMavenJobInFolder/config.xml
+++ b/src/test/resources/folder/jobs/aFolder/jobs/bMavenJobInFolder/config.xml
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<maven2-moduleset plugin="maven-plugin@2.13">
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.cloudbees.plugins.deployer.DeployNowJobProperty plugin="deployer-framework@1.1">
+      <oneClickDeploy>false</oneClickDeploy>
+      <hosts>
+        <com.cloudbees.plugins.deployer.impl.amazon.HostImpl plugin="cloudbees-aws-deployer@1.15">
+          <targets class="java.util.Collections$UnmodifiableRandomAccessList" resolves-to="java.util.Collections$UnmodifiableList">
+            <c class="list"/>
+            <list reference="../c"/>
+          </targets>
+          <credentialsId></credentialsId>
+        </com.cloudbees.plugins.deployer.impl.amazon.HostImpl>
+      </hosts>
+    </com.cloudbees.plugins.deployer.DeployNowJobProperty>
+    <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28"/>
+    <com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty plugin="build-failure-analyzer@1.16.0">
+      <doNotScan>false</doNotScan>
+    </com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17.1">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+      <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
+      <paramsToUseForLimit></paramsToUseForLimit>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <aggregatorStyleBuild>true</aggregatorStyleBuild>
+  <incrementalBuild>false</incrementalBuild>
+  <ignoreUpstremChanges>false</ignoreUpstremChanges>
+  <ignoreUnsuccessfulUpstreams>false</ignoreUnsuccessfulUpstreams>
+  <archivingDisabled>false</archivingDisabled>
+  <siteArchivingDisabled>false</siteArchivingDisabled>
+  <fingerprintingDisabled>false</fingerprintingDisabled>
+  <resolveDependencies>false</resolveDependencies>
+  <processPlugins>false</processPlugins>
+  <mavenValidationLevel>-1</mavenValidationLevel>
+  <runHeadless>false</runHeadless>
+  <disableTriggerDownstreamProjects>false</disableTriggerDownstreamProjects>
+  <blockTriggerWhenBuilding>true</blockTriggerWhenBuilding>
+  <settings class="jenkins.mvn.DefaultSettingsProvider"/>
+  <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+  <reporters/>
+  <publishers/>
+  <buildWrappers/>
+  <prebuilders/>
+  <postbuilders/>
+  <runPostStepsIfResult>
+    <name>FAILURE</name>
+    <ordinal>2</ordinal>
+    <color>RED</color>
+    <completeBuild>true</completeBuild>
+  </runPostStepsIfResult>
+</maven2-moduleset>

--- a/src/test/resources/folder/jobs/aFolder/xml-api-response.xml
+++ b/src/test/resources/folder/jobs/aFolder/xml-api-response.xml
@@ -1,0 +1,12 @@
+<folder>
+    <job>
+        <description/>
+        <name>bFreestyleJobInFolder</name>
+        <url>${baseUrl}/job/folder/job/aFolder/job/bFreestyleJobInFolder/</url>
+    </job>
+    <job>
+        <description/>
+        <name>bMavenJobInFolder</name>
+        <url>${baseUrl}/job/folder/job/aFolder/job/bMavenJobInFolder/</url>
+    </job>
+</folder>

--- a/src/test/resources/folder/jobs/aFreestyleJobInFolder/config.xml
+++ b/src/test/resources/folder/jobs/aFreestyleJobInFolder/config.xml
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.cloudbees.plugins.deployer.DeployNowJobProperty plugin="deployer-framework@1.1">
+      <oneClickDeploy>false</oneClickDeploy>
+      <hosts>
+        <com.cloudbees.plugins.deployer.impl.amazon.HostImpl plugin="cloudbees-aws-deployer@1.15">
+          <targets class="java.util.Collections$UnmodifiableRandomAccessList" resolves-to="java.util.Collections$UnmodifiableList">
+            <c class="list"/>
+            <list reference="../c"/>
+          </targets>
+          <credentialsId></credentialsId>
+        </com.cloudbees.plugins.deployer.impl.amazon.HostImpl>
+      </hosts>
+    </com.cloudbees.plugins.deployer.DeployNowJobProperty>
+    <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28"/>
+    <com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty plugin="build-failure-analyzer@1.16.0">
+      <doNotScan>false</doNotScan>
+    </com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17.1">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+      <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
+      <paramsToUseForLimit></paramsToUseForLimit>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/folder/jobs/aMavenJobInFolder/config.xml
+++ b/src/test/resources/folder/jobs/aMavenJobInFolder/config.xml
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<maven2-moduleset plugin="maven-plugin@2.13">
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.cloudbees.plugins.deployer.DeployNowJobProperty plugin="deployer-framework@1.1">
+      <oneClickDeploy>false</oneClickDeploy>
+      <hosts>
+        <com.cloudbees.plugins.deployer.impl.amazon.HostImpl plugin="cloudbees-aws-deployer@1.15">
+          <targets class="java.util.Collections$UnmodifiableRandomAccessList" resolves-to="java.util.Collections$UnmodifiableList">
+            <c class="list"/>
+            <list reference="../c"/>
+          </targets>
+          <credentialsId></credentialsId>
+        </com.cloudbees.plugins.deployer.impl.amazon.HostImpl>
+      </hosts>
+    </com.cloudbees.plugins.deployer.DeployNowJobProperty>
+    <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28"/>
+    <com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty plugin="build-failure-analyzer@1.16.0">
+      <doNotScan>false</doNotScan>
+    </com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17.1">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+      <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
+      <paramsToUseForLimit></paramsToUseForLimit>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <aggregatorStyleBuild>true</aggregatorStyleBuild>
+  <incrementalBuild>false</incrementalBuild>
+  <ignoreUpstremChanges>false</ignoreUpstremChanges>
+  <ignoreUnsuccessfulUpstreams>false</ignoreUnsuccessfulUpstreams>
+  <archivingDisabled>false</archivingDisabled>
+  <siteArchivingDisabled>false</siteArchivingDisabled>
+  <fingerprintingDisabled>false</fingerprintingDisabled>
+  <resolveDependencies>false</resolveDependencies>
+  <processPlugins>false</processPlugins>
+  <mavenValidationLevel>-1</mavenValidationLevel>
+  <runHeadless>false</runHeadless>
+  <disableTriggerDownstreamProjects>false</disableTriggerDownstreamProjects>
+  <blockTriggerWhenBuilding>true</blockTriggerWhenBuilding>
+  <settings class="jenkins.mvn.DefaultSettingsProvider"/>
+  <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+  <reporters/>
+  <publishers/>
+  <buildWrappers/>
+  <prebuilders/>
+  <postbuilders/>
+  <runPostStepsIfResult>
+    <name>FAILURE</name>
+    <ordinal>2</ordinal>
+    <color>RED</color>
+    <completeBuild>true</completeBuild>
+  </runPostStepsIfResult>
+</maven2-moduleset>

--- a/src/test/resources/folder/xml-api-response.xml
+++ b/src/test/resources/folder/xml-api-response.xml
@@ -1,0 +1,17 @@
+<folder>
+    <job>
+        <description/>
+        <name>aFolder</name>
+        <url>${baseUrl}/job/folder/job/aFolder/</url>
+    </job>
+    <job>
+        <description/>
+        <name>aFreestyleJobInFolder</name>
+        <url>${baseUrl}/job/folder/job/aFreestyleJobInFolder/</url>
+    </job>
+    <job>
+        <description/>
+        <name>aMavenJobInFolder</name>
+        <url>${baseUrl}/job/folder/job/aMavenJobInFolder/</url>
+    </job>
+</folder>

--- a/src/test/resources/job/config.xml
+++ b/src/test/resources/job/config.xml
@@ -1,0 +1,97 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.cloudbees.plugins.deployer.DeployNowJobProperty plugin="deployer-framework@1.1">
+      <oneClickDeploy>false</oneClickDeploy>
+      <hosts/>
+    </com.cloudbees.plugins.deployer.DeployNowJobProperty>
+    <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28"/>
+    <com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty plugin="build-failure-analyzer@1.16.0">
+      <doNotScan>false</doNotScan>
+    </com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.19.2">
+      <projectUrl>https://github.com/Evildethow/test-ghpr-plugin/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17.1">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <categories class="java.util.concurrent.CopyOnWriteArrayList"/>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+      <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
+      <paramsToUseForLimit></paramsToUseForLimit>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.5.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <refspec>+refs/pull/*:refs/remotes/origin/pr/*</refspec>
+        <url>git@github.com:Evildethow/test-ghpr-plugin.git</url>
+        <credentialsId>23dfb353-8d71-40d3-9773-314613f37221</credentialsId>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>${sha1}</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@1.32.6">
+      <spec>H/5 * * * *</spec>
+      <latestVersion>3</latestVersion>
+      <configVersion>3</configVersion>
+      <adminlist></adminlist>
+      <allowMembersOfWhitelistedOrgsAsAdmin>false</allowMembersOfWhitelistedOrgsAsAdmin>
+      <orgslist></orgslist>
+      <cron>H/5 * * * *</cron>
+      <buildDescTemplate></buildDescTemplate>
+      <onlyTriggerPhrase>false</onlyTriggerPhrase>
+      <useGitHubHooks>false</useGitHubHooks>
+      <permitAll>false</permitAll>
+      <whitelist></whitelist>
+      <autoCloseFailedPullRequests>false</autoCloseFailedPullRequests>
+      <displayBuildErrorsOnDownstreamBuilds>false</displayBuildErrorsOnDownstreamBuilds>
+      <whiteListTargetBranches>
+        <org.jenkinsci.plugins.ghprb.GhprbBranch>
+          <branch></branch>
+        </org.jenkinsci.plugins.ghprb.GhprbBranch>
+      </whiteListTargetBranches>
+      <gitHubAuthId>fcad1491-7719-4dd5-8eb3-2d6da3503cac</gitHubAuthId>
+      <triggerPhrase></triggerPhrase>
+      <skipBuildPhrase>.*\[skip\W+ci\].*</skipBuildPhrase>
+      <extensions>
+        <org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
+          <commitStatusContext></commitStatusContext>
+          <triggeredStatus></triggeredStatus>
+          <startedStatus></startedStatus>
+          <statusUrl></statusUrl>
+          <addTestResults>false</addTestResults>
+        </org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
+      </extensions>
+    </org.jenkinsci.plugins.ghprb.GhprbTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/xml-api-response.xml
+++ b/src/test/resources/xml-api-response.xml
@@ -1,0 +1,12 @@
+<hudson>
+    <job>
+        <description/>
+        <name>folder</name>
+        <url>${baseUrl}/job/folder/</url>
+    </job>
+    <job>
+        <description/>
+        <name>job</name>
+        <url>${baseUrl}/job/job/</url>
+    </job>
+</hudson>


### PR DESCRIPTION
@reviewbybees cc @escoem 

Looks like this duplicates effort in https://github.com/jenkinsci/job-import-plugin/pull/4 :(

I actually like [this PR](https://github.com/jenkinsci/job-import-plugin/pull/4) better as it seems the author has updated the UI to allow being selective about child jobs in folders, which I didn't bother with. The only thing my PR has over this PR is that it adds tests and a mini test framework for stubbing the remote Jenkins, which can be re-used.
## Notes for release
- Jenkins base version bumped `1.580 -> 1.609.1` (required for `cloudbees-folder` dependency)
- Transient dependency `cloudbees-folder:5.12` added
