### PR TITLE
Job import from folders

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
@@ -125,7 +125,7 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
               }
 
               try {
-                  inputStream = URLUtils.fetchUrl(remoteJob.getUrl() + "/config.xml", username, password);
+                  inputStream = URLUtils.fetchUrl(getConfigXMLPath(remoteJob.getUrl()), username, password);
                   TopLevelItem topLevelItem = Jenkins.getInstance().createProjectFromXML(remoteJob.getName(), inputStream);
                   boolean disableProject = request.getParameter("disable-" + jobUrl) != null;
                   if (topLevelItem instanceof AbstractProject && disableProject) {
@@ -167,7 +167,15 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
 
     response.forwardToPreviousPage(request);
   }
-
+  
+  private String getConfigXMLPath(String jobURL){
+    if("/".equals(jobURL.substring(jobURL.length()-1, jobURL.length()))){
+      return jobURL + "config.xml";
+    }else{
+      return jobURL + "/config.xml";
+    }
+  }
+  
   public void doQuery(final StaplerRequest request, final StaplerResponse response) throws ServletException,
       IOException {
     remoteJobs.clear();


### PR DESCRIPTION
This PR is not a more nicer, but a simpler solution to the [#12](https://github.com/jenkinsci/job-import-plugin/pull/12). 
If you want to import a job from a plugin, the query url needs to contain the folder(ex: http://jenkins.com/job/Folder1/).

The changes required for this, is to make sure that you remove a slash to the config.xml path, if it is a job from a folder.
ex(how it is now): http://jenkins.com/job/Folder1/job/JobName1//config.xml