### PR TITLE
JENKINS-45195 Import job fails when user lacks overall / administer

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
@@ -30,6 +30,7 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.RootAction;
 import hudson.model.TopLevelItem;
+import hudson.security.AccessDeniedException2;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
@@ -130,7 +131,18 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
               doImportInternal(childJob.getUrl());
             }
           }
-          Jenkins.getActiveInstance().doReload();
+
+
+
+          try{
+            Jenkins instance= Jenkins.getActiveInstance();
+            instance.checkPermission(instance.ADMINISTER);
+            Jenkins.getActiveInstance().doReload();
+          } catch(AccessDeniedException2 ex2){
+            remoteJobsImportStatus.get(remoteJob).setStatus(MessagesUtils.formatSuccessNotReloaded());
+            LOG.log(Level.INFO, "Failed to reload Jenkins config because the user lacks the Overall Administer permission");
+
+          }
         }
 
         catch (final Exception e) {

--- a/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
@@ -132,8 +132,6 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
             }
           }
 
-
-
           try{
             Jenkins instance= Jenkins.getActiveInstance();
             instance.checkPermission(instance.ADMINISTER);

--- a/src/main/java/org/jenkins/ci/plugins/jobimport/MessagesUtils.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/MessagesUtils.java
@@ -47,7 +47,7 @@ public final class MessagesUtils {
     return Messages.Job_Import_Plugin_Import_Success();
   }
   public static String formatSuccessNotReloaded() {
-    return Messages.Job_Import_Plugin_Import_Success_Not_Reloaded();
+    return Messages.Job_Import_Plugin_Import_Success_NotReloaded();
   }
   /**
    * Static-only access.

--- a/src/main/java/org/jenkins/ci/plugins/jobimport/MessagesUtils.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/MessagesUtils.java
@@ -46,7 +46,9 @@ public final class MessagesUtils {
   public static String formatSuccess() {
     return Messages.Job_Import_Plugin_Import_Success();
   }
-
+  public static String formatSuccessNotReloaded() {
+    return Messages.Job_Import_Plugin_Import_Success_Not_Reloaded();
+  }
   /**
    * Static-only access.
    */

--- a/src/main/resources/org/jenkins/ci/plugins/jobimport/Messages.properties
+++ b/src/main/resources/org/jenkins/ci/plugins/jobimport/Messages.properties
@@ -25,5 +25,6 @@
 DisplayName            =  Job Import Plugin
 
 Job.Import.Plugin.Import.Success             =  SUCCESS
+Job.Import.Plugin.Import.Success.NotReloaded =  SUCCESS - Reload was not performed due to lack of Overall/Administer permissions.
 Job.Import.Plugin.Import.Failed.Duplicate    =  FAILED - Duplicate Job Name
 Job.Import.Plugin.Import.Failed.Exception    =  FAILED - {0}


### PR DESCRIPTION
When a user lacking the Overall/Administer permission imports a job the operation shows as failed even if the job is imported. What fails is the doReload() operation that requires that permission.

One option was to remove the doReload() operation, but I opted to provide a different message if the user lacks the Overall/Administer permission.

cc @escoem 