### PR TITLE
[JENKINS-60493] configure should return true

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportGlobalConfig.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportGlobalConfig.java
@@ -33,7 +33,7 @@ public class JobImportGlobalConfig extends GlobalConfiguration {
     @Override
     public boolean configure(final StaplerRequest req, final JSONObject formData) {
         setSites(req.bindJSONToList(JenkinsSite.class, formData.get("sites")));
-        return false;
+        return true;
     }
 
     public List<JenkinsSite> getSites() {


### PR DESCRIPTION
[JENKINS-60493](https://issues.jenkins-ci.org/browse/JENKINS-60493)

GlobalConfiguration.configure must return `true` otherwise you will be redirect to current page.

cc. @omehegan 