### PR TITLE
[JENKINS-66191] Fix icon size in dashboard

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
+++ b/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java
@@ -297,7 +297,7 @@ public final class JobImportAction implements RootAction, Describable<JobImportA
   }
 
   public String getIconFileName() {
-    return "/images/32x32/setting.png";
+    return "setting.png";
   }
 
   public String getUrlName() {


### PR DESCRIPTION
I found a problem with icon size in job-import-plugin that is 32x32 instead 24x24 so it make sidebar menu to be bigger than should be.

I open a issue to jenkins: https://issues.jenkins.io/browse/JENKINS-66191

I think this is the line of code we should change to get aligned with other icons

https://github.com/jenkinsci/job-import-plugin/blob/2578ed330d35328f9bdeca219f7b98beefe68a71/src/main/java/org/jenkins/ci/plugins/jobimport/JobImportAction.java#L300